### PR TITLE
remove unsupported field

### DIFF
--- a/apis/apps/composition.yaml
+++ b/apis/apps/composition.yaml
@@ -7,10 +7,6 @@ spec:
     apiVersion: platform.upbound.io/v1
     kind: App
   mode: Pipeline
-  apiDependencies:
-  - k8s:
-      version: v1.33.0
-    type: k8s
   pipeline:
   - functionRef:
       name: upbound-configuration-app-modelapp

--- a/apis/apps/definition.yaml
+++ b/apis/apps/definition.yaml
@@ -133,8 +133,6 @@ spec:
                             type: object
                           nameOverride:
                             type: string
-                          namespace:
-                            type: string
                           nodeSelector:
                             additionalProperties:
                               type: string

--- a/examples/app/example-full.yaml
+++ b/examples/app/example-full.yaml
@@ -2,13 +2,12 @@ apiVersion: platform.upbound.io/v1
 kind: App
 metadata:
   name: example-full
-  namespace: default
+  namespace: test-namespace
 spec:
   parameters:
     workloads:
       app1:
         replicaCount: 2
-        namespace: test-namespace
 
         image:
           repository: nginx

--- a/functions/app/main.k
+++ b/functions/app/main.k
@@ -44,8 +44,6 @@ _workloads = oxr.spec.parameters.workloads if oxr.spec?.parameters?.workloads el
 
 # Function to create resources for a single workload
 _createWorkloadResources = lambda workloadName: str, workloadConfig: any -> [any] {
-    _namespace = workloadConfig.namespace if workloadConfig.namespace else None
-
     # Generate common metadata for this workload
     _commonMetadata = {
         labels = {
@@ -60,14 +58,12 @@ _createWorkloadResources = lambda workloadName: str, workloadConfig: any -> [any
     _serviceAccountInput = {
         metadata = _metadata("${workloadName}-serviceaccount") | _commonMetadata
         name = workloadName
-        namespace = _namespace
         serviceAccount = workloadConfig.serviceAccount
     }
 
     _deploymentInput = {
         metadata = _metadata("${workloadName}-deployment") | _commonMetadata
         name = workloadName
-        namespace = _namespace
         replicaCount = workloadConfig.replicaCount
         image = workloadConfig.image
         imagePullSecrets = workloadConfig.imagePullSecrets
@@ -91,14 +87,12 @@ _createWorkloadResources = lambda workloadName: str, workloadConfig: any -> [any
     _serviceInput = {
         metadata = _metadata("${workloadName}-service") | _commonMetadata
         name = workloadName
-        namespace = _namespace
         service = workloadConfig.service
     }
 
     _ingressInput = {
         metadata = _metadata("${workloadName}-ingress") | _commonMetadata
         name = workloadName
-        namespace = _namespace
         ingress = workloadConfig.ingress
         service = workloadConfig.service
     }
@@ -106,7 +100,6 @@ _createWorkloadResources = lambda workloadName: str, workloadConfig: any -> [any
     _hpaInput = {
         metadata = _metadata("${workloadName}-hpa") | _commonMetadata
         name = workloadName
-        namespace = _namespace
         autoscaling = workloadConfig.autoscaling
     }
 


### PR DESCRIPTION
### Description of your changes

- Composition does not support `apiDependencies`
- Because Namespaced v2 compositions can only deploy to one namespace. Remove _namespace settings in the app workload and main.k

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
